### PR TITLE
ValidationError catch for events ics

### DIFF
--- a/events/views.py
+++ b/events/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.views import redirect_to_login
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import reverse_lazy, reverse
 from django.db.models import Q, Count, Sum
@@ -828,6 +828,9 @@ def ical(request, event_pk=None):
             user = api_key.user
         except APIKey.DoesNotExist:
             pass
+        except ValidationError:
+            # Bad or Wrong User PK or API key (key)
+            raise Http404
 
     if event_pk is None:
         # We want multiple events


### PR DESCRIPTION
There was a badly formed API Key UUID that was sent to the site, throwing a ValidationError
Because the credentials are bad, there's no point on letting the user see that it passed, so it goes directly to 404 (do not pass Go, do not collect $200 ... jk)