### PR TITLE
Add Berkeley mandated Student Org URL

### DIFF
--- a/settings/production.py
+++ b/settings/production.py
@@ -67,6 +67,7 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 ALLOWED_HOSTS = [
     'tbp.apphost.ocf.berkeley.edu',
+    'tbp.studentorg.berkeley.edu',
     'tbp-dev.apphost.ocf.berkeley.edu',
     'tbp.berkeley.edu'
 ]


### PR DESCRIPTION
https://www.ocf.berkeley.edu/docs/services/vhost/subdomain-migration/