### PR TITLE
Updating Email domain for new Berkeley Domain Policy

### DIFF
--- a/settings/project.py
+++ b/settings/project.py
@@ -11,7 +11,7 @@ SITE_TAG = 'TBP'
 
 HOSTNAME = 'tbp.berkeley.edu'
 
-DEFAULT_FROM_EMAIL = 'tbpwebsite@' + HOSTNAME
+DEFAULT_FROM_EMAIL = 'tbpwebsite@' + 'tbp.studentorg.berkeley.edu'
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 # An email address for receiving test emails


### PR DESCRIPTION
re: https://www.ocf.berkeley.edu/docs/services/vhost/subdomain-migration/ 

"We have already updated your email addresses to use myclub.studentorg.berkeley.edu"