### PR TITLE
Fix Project Report Book Feature

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -28,6 +28,7 @@ pillow==6.2.0
 pycparser==2.19
 pyjwt==1.7.1
 pynacl==1.3.0
+pypandoc==1.5
 python3-openid==3.1.0 ; python_version >= '3.0'
 pytz==2019.3
 git+https://github.com/TBP-IT/recaptcha-client-1.0.6-py3

--- a/config/tbpweb-dev.yml
+++ b/config/tbpweb-dev.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.7
   - pip
   - pypandoc
-  - pdflatex
   - pip:
     - -r requirements.txt
     - pre-commit==1.14.4

--- a/config/tbpweb-dev.yml
+++ b/config/tbpweb-dev.yml
@@ -1,7 +1,11 @@
 name: tbpweb-dev
+channels:
+  - conda-forge
 dependencies:
   - python=3.7
   - pip
+  - pypandoc
+  - pdflatex
   - pip:
     - -r requirements.txt
     - pre-commit==1.14.4
@@ -9,8 +13,6 @@ dependencies:
     - pytest-django==3.4.7
     - tox==3.7.0
     - livereload==2.6.0
-    # - coverage[toml]==6.3.2
-    # - black==22.3.0
 variables:
   TBPWEB_MODE: "dev"
   DJANGO_SETTINGS_MODULE: "settings"

--- a/config/tbpweb-prod.yml
+++ b/config/tbpweb-prod.yml
@@ -1,7 +1,11 @@
 name: tbpweb-prod
+channels:
+  - conda-forge
 dependencies:
   - python=3.7
   - pip
+  - pypandoc
+  - pdflatex
   - pip:
     - -r requirements.txt
     - mysqlclient==2.1.0

--- a/config/tbpweb-prod.yml
+++ b/config/tbpweb-prod.yml
@@ -5,7 +5,6 @@ dependencies:
   - python=3.7
   - pip
   - pypandoc
-  - pdflatex
   - pip:
     - -r requirements.txt
     - mysqlclient==2.1.0

--- a/project_reports/exceptions.py
+++ b/project_reports/exceptions.py
@@ -1,6 +1,5 @@
 import sys
 
-
 class DelayedException(object):
     # Taken from http://stackoverflow.com/questions/6126007 ...
     # /python-getting-a-traceback-from-a-multiprocessing-process
@@ -9,4 +8,4 @@ class DelayedException(object):
         _, _, self.traceback = sys.exc_info()
 
     def re_raise(self):
-        raise self.exc, None, self.traceback
+        raise self.exc.with_traceback(self.traceback)

--- a/project_reports/forms.py
+++ b/project_reports/forms.py
@@ -34,7 +34,7 @@ class ProjectReportBookExportForm(forms.Form):
     
     def __init__(self, *args, **kwargs):
         super(ProjectReportBookExportForm, self).__init__(*args, **kwargs)
-        self.terms.choices = self.get_term_choices()
+        self.fields['terms'].choices = self.get_term_choices()
         
     
     def get_term_choices(self):

--- a/project_reports/management/commands/generate_pr_book.py
+++ b/project_reports/management/commands/generate_pr_book.py
@@ -23,18 +23,21 @@ tblib.pickling_support.install()
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('pr_book_id')
+
     def handle(self, *args, **options):
         # Save the PDF to the PR book object, or save the exception if there
         # there was a failure
         try:
             self.unwrapped_handle(*args, **options)
         except Exception as e:  # pylint: disable=broad-except
-            pr_book = ProjectReportBook.objects.get(id=args[0])
+            pr_book = ProjectReportBook.objects.get(id=options['pr_book_id'])
             pr_book.exception = DelayedException(e)
             pr_book.save()
 
     def unwrapped_handle(self, *args, **options):
-        pr_book = ProjectReportBook.objects.get(id=args[0])
+        pr_book = ProjectReportBook.objects.get(id=options['pr_book_id'])
 
         terms = pr_book.terms.order_by('id')
         president = Officer.objects.get(

--- a/project_reports/management/commands/generate_pr_book.py
+++ b/project_reports/management/commands/generate_pr_book.py
@@ -1,4 +1,4 @@
-from django.core.files import File
+from django.conf import settings
 from django.core.management import BaseCommand
 from django.template.loader import render_to_string
 
@@ -117,19 +117,14 @@ class Command(BaseCommand):
         run_thread()
         run_thread()  # run LaTeX twice to create table of contents
 
-        with open('book.pdf', encoding='utf-8', errors='ignore') as pr_book_pdf:
-            print("os.getcwd() before save", os.getcwd(), dirname)
-            print(pr_book_pdf.name)
-            print("LOL")
-            # print( "isfile", os.path.isfile('book.pdf') )
-            print("LOL read")
-            pr_book.pdf.save(name='{}.pdf'.format(pr_book.pk), content=File(pr_book_pdf))
-            print("Saved")
+        pr_book_name = '{}.pdf'.format(pr_book.pk)
+        pr_book.pdf.name = pr_book.pdf.field.upload_to + pr_book_name
+        shutil.copyfile(src=os.path.join(os.getcwd(), 'book.pdf'), dst=os.path.join(settings.PRIVATE_STORAGE_ROOT, pr_book.pdf.name))
 
         pr_book.save()
 
         os.chdir(orig_dir)
-        # shutil.rmtree(dirname)
+        shutil.rmtree(dirname)
 
     def get_pandoc_header(self, terms):
         return render_to_string(

--- a/project_reports/management/commands/generate_pr_book.py
+++ b/project_reports/management/commands/generate_pr_book.py
@@ -81,7 +81,6 @@ class Command(BaseCommand):
 
         def run(context):
             # Run LaTeX, storing information in the `context` dictionary
-            print("os.getcwd()", os.getcwd())
             pdflatex_command = ['pdflatex', 'book.tex']
             context['proc'] = subprocess.run(
                 pdflatex_command,

--- a/project_reports/views.py
+++ b/project_reports/views.py
@@ -222,6 +222,7 @@ class ProjectReportBookDownloadView(DetailView, PrivateStorageDetailView):
         elif not pr_book.pdf:
             return render(request, 'project_reports/download_book.html', {})
         else:
+            self.object = pr_book
             response = super(PrivateStorageDetailView, self).get(request, args, kwargs)
             response.content_type = 'application/pdf'
             response['Content-Disposition'] = \


### PR DESCRIPTION
Requires the development machine to install [TexLive](https://www.tug.org/texlive/), but doesn't need it for the entire development of tbpweb
Will be using OCF's own installed TexLive

If your console can run "pdflatex" after installing the TexLive out of the box with default settings, you should be fine

Only the Project Report Book requires the install of TexLive, no where else on tbpweb
So it will not be bundled in with the conda environment due to the very small need to develop on this feature ... except for maintenance then install TexLive directly on your machine (not using Conda)

NOTE: conda-forage's TexLive-core does not work