### PR TITLE
Block off counting Elective Requirement if it is not set

### DIFF
--- a/candidates/views.py
+++ b/candidates/views.py
@@ -953,7 +953,7 @@ class CandidateProgressByReqView(TemplateView, CandidateProgressMixin):
             for req_progress in progress_item['requirements']:
                 requirement = req_progress['requirement']
                 # Exclude progresses with the wrong requirement
-                if (self.display_req and self.display_req != requirement):
+                if self.display_req and (self.display_req != requirement):
                     continue
                 req_name = requirement.get_name()
                 if req_name not in progresses_by_req:

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -953,7 +953,7 @@ class CandidateProgressByReqView(TemplateView, CandidateProgressMixin):
             for req_progress in progress_item['requirements']:
                 requirement = req_progress['requirement']
                 # Exclude progresses with the wrong requirement
-                if (not requirement) or (self.display_req and self.display_req != requirement):
+                if (self.display_req and self.display_req != requirement):
                     continue
                 req_name = requirement.get_name()
                 if req_name not in progresses_by_req:
@@ -998,8 +998,6 @@ class CandidateProgressStatsView(TemplateView, CandidateProgressMixin):
         total_unfinished = 0
         for progress_item in progress.values():
             for req_progress in progress_item['requirements']:
-                if not req_progress['requirement']:
-                    continue
                 req_name = req_progress['requirement'].get_name()
                 completed = req_progress['completed']
                 required = req_progress['required']


### PR DESCRIPTION
A fix was made in https://github.com/TBP-IT/tbpweb/pull/92 which would have worked and is fine
There was a TODO by 'ehy' that made it explicit that if an Elective Requirement is not set, the code may not work

This PR reverts #92 and provides the correct fix to deal with the Elective requirement being the root cause of the issue by simply not counting it and blocking that requirement being counted