### PR TITLE
Write comment note in case conda env update fails

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -155,6 +155,8 @@ def create_conda(c: Connection):
 def update_conda(c: Connection):
     print("-- Update Conda Environment and dependencies")
     with c.cd(c.release_path):
+        # If this command fails due to not enough OCF resources at the time,
+        #  ok to comment the line out
         c.run("conda env update -f config/tbpweb-prod.yml")
         c.run("conda info -a")  # Print post-creation properties
 


### PR DESCRIPTION
Write simple note when the Conda update fails sometimes, especially when OCF runs out of resources
To test upon next deploy in case stray syntax shows up