### PR TITLE
Remove old account password reset notice - from new server move

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -9,9 +9,6 @@
 {% endblock intro %}
 
 {% block content %}
-
-<strong>NOTE: All accounts created before August 2022 will need to reset their password.</strong>
-
 <form method="post" action="{{ request.path }}" class="form-narrow">
   {% csrf_token %}
   {% include '_form.html' %}


### PR DESCRIPTION
It's been a few years already, so if people fail due to invalid password (Django checks) worst case they reset their password

Related feature to consider if an explicit notice is desired: https://github.com/ochan1/tbpweb/tree/pw_req_notice